### PR TITLE
fix: IPv6 support for thumbnails

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -25,11 +25,14 @@ export const getThumb = (thumbnails: Thumbnail[], path: string, large = true) =>
       }
       if (thumb) {
         if (thumb.relative_path && thumb.relative_path.length > 0) {
+          const url = new URL(apiUrl ?? document.location.origin)
+          url.pathname = (path === '')
+            ? url.pathname = `/server/files/gcodes/${thumb.relative_path}`
+            : `/server/files/gcodes/${path}/${thumb.relative_path}`
+
           return {
             ...thumb,
-            absolute_path: (path === '')
-              ? encodeURI(`${apiUrl}/server/files/gcodes/${thumb.relative_path}`)
-              : encodeURI(`${apiUrl}/server/files/gcodes/${path}/${thumb.relative_path}`)
+            absolute_path: url.toString()
           }
         }
         if (thumb.data) {


### PR DESCRIPTION
IPv6 support for encodeURI() is broken. This replaces encodeURI() with an implementation using the URL API, fully supporting IPv6

Signed-off-by: Mathis Mensing <matmen@dreadful.tech>