### PR TITLE
fix: use v-model for TimelapseRenderSettingsDialog

### DIFF
--- a/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
+++ b/src/components/widgets/timelapse/TimelapseRenderSettingsDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <v-dialog
-    :value="open"
+    :value="value"
     :max-width="640"
-    @click:outside="$emit('close')"
+    @input="$emit('input', $event)"
   >
-    <v-card v-if="open">
+    <v-card v-if="value">
       <v-card-title class="card-heading py-2">
         <span class="focus--text">{{ $t('app.timelapse.title.render_settings') }}</span>
 
@@ -12,7 +12,7 @@
         <app-btn
           color=""
           icon
-          @click="$emit('close')"
+          @click="$emit('input', false)"
         >
           <v-icon>$close</v-icon>
         </app-btn>
@@ -176,8 +176,11 @@ import { TimelapseLastFrame, TimelapseSettings } from '@/store/timelapse/types'
   components: { AppSetting }
 })
 export default class TimelapseRenderSettingsDialog extends Mixins(StateMixin) {
-  @Prop({ type: Boolean }) open = false
-  @Prop({ type: Boolean }) renderable = false
+  @Prop({ type: Boolean, required: true })
+  value!: boolean
+
+  @Prop({ type: Boolean, required: true })
+  renderable!: boolean
 
   @Ref('outputFramerateElement') outputFramerateElement!: any
   @Ref('targetLengthElement') targetLengthElement!: any

--- a/src/views/Timelapse.vue
+++ b/src/views/Timelapse.vue
@@ -28,9 +28,9 @@
     </v-col>
 
     <timelapse-render-settings-dialog
-      :open="renderDialog.open"
+      v-if="renderDialog.open"
+      v-model="renderDialog.open"
       :renderable="renderDialog.renderable"
-      @close="closeRenderDialog"
     />
   </v-row>
 </template>
@@ -58,10 +58,6 @@ export default class Timelapse extends Mixins(StateMixin) {
 
   openRenderDialog (renderable = false) {
     this.renderDialog = { open: true, renderable }
-  }
-
-  closeRenderDialog () {
-    this.renderDialog.open = false
   }
 }
 </script>


### PR DESCRIPTION
This changes the way we show/hide the dialog by using `v-model` (as in most of the dialogs we have)

Also ensures that dialog is not part of tree (though hidden -- will send a separate PR to main repo regarding this)

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>