### PR TITLE
fix: layout and naming consistency

### DIFF
--- a/src/components/widgets/filesystem/FilePreviewDialog.vue
+++ b/src/components/widgets/filesystem/FilePreviewDialog.vue
@@ -5,23 +5,16 @@
   >
     <v-card v-if="file.open">
       <v-card-title class="card-heading py-2">
-        <v-col cols="11">
-          <v-icon left>
-            ${{ icon }}
-          </v-icon>
-          <span class="focus--text">
-            {{ file.filename }}
-          </span>
-        </v-col>
+        <span class="focus--text">{{ file.filename }}</span>
 
-        <v-col
-          class="text-right"
-          cols="1"
+        <v-spacer />
+        <app-btn
+          color=""
+          icon
+          @click="$emit('close')"
         >
-          <v-icon @click="$emit('close')">
-            $close
-          </v-icon>
-        </v-col>
+          <v-icon>$close</v-icon>
+        </app-btn>
       </v-card-title>
 
       <v-card-text class="py-4">

--- a/src/components/widgets/filesystem/FileSystem.vue
+++ b/src/components/widgets/filesystem/FileSystem.vue
@@ -109,7 +109,7 @@
       @cancel="handleCancelUpload"
     />
 
-    <file-preview
+    <file-preview-dialog
       :file="filePreviewState"
       removable
       downloadable
@@ -150,7 +150,7 @@ import FileNameDialog from './FileNameDialog.vue'
 import FileSystemDragOverlay from './FileSystemDragOverlay.vue'
 import FileSystemDownloadDialog from './FileSystemDownloadDialog.vue'
 import FileSystemUploadDialog from './FileSystemUploadDialog.vue'
-import FilePreview from './FilePreviewDialog.vue'
+import FilePreviewDialog from './FilePreviewDialog.vue'
 import Axios, { AxiosResponse } from 'axios'
 import { AppTableHeader } from '@/types'
 
@@ -171,7 +171,7 @@ import { AppTableHeader } from '@/types'
     FileNameDialog,
     FileSystemDownloadDialog,
     FileSystemUploadDialog,
-    FilePreview
+    FilePreviewDialog
   }
 })
 export default class FileSystem extends Mixins(StateMixin, FilesMixin, ServicesMixin) {


### PR DESCRIPTION
Changed the layout of the dialog to match the other dialogs.

Renamed the import to keep consistent naming.

Signed-off-by: Pedro Lamas <pedrolamas@gmail.com>